### PR TITLE
fix: inline Netlify Identity script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix Netlify Identity script by inlining
+
 ## [0.1.0] - 2022-11-25
 
 - Initial release of `astro-netlify-components` 🎉

--- a/CMS.astro
+++ b/CMS.astro
@@ -5,7 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Admin Page</title>
-    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"
+    <script
+      is:inline
+      src="https://identity.netlify.com/v1/netlify-identity-widget.js"
     ></script>
     <slot name="head" />
   </head>


### PR DESCRIPTION
There is an error in production where the script is blocked for a CORS violation:

``` 
GET https://identity.netlify.com/v1/netlify-identity-widget.js net::ERR_FAILED 200
hoisted.9c0718d3.js:1
```

Using `is:inline` should resolve this.