### PR TITLE
feat: add Identity component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add `Identity` component
+- Add `Identity` component (#5)
 - Add jumping cursor fix for Netlify CMS (#4)
 
 ## [0.1.1] - 2022-12-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `Identity` component
 - Add jumping cursor fix for Netlify CMS (#4)
 
 ## [0.1.1] - 2022-12-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Add `Identity` component (#5)
+- Add `data-source=astro-netlify-components` attribute to top-level element in each component (#5)
 - Add jumping cursor fix for Netlify CMS (#4)
 
 ## [0.1.1] - 2022-12-05

--- a/CMS.astro
+++ b/CMS.astro
@@ -1,14 +1,15 @@
+---
+import Identity from "./Identity.astro";
+---
+
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-source="astro-netlify-components">
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Admin Page</title>
-    <script
-      is:inline
-      src="https://identity.netlify.com/v1/netlify-identity-widget.js"
-    ></script>
+    <Identity />
     <style>
       /* See https://github.com/netlify/netlify-cms/issues/5092 */
       [data-slate-editor] {

--- a/Form.astro
+++ b/Form.astro
@@ -26,7 +26,7 @@ if (rest.action && rest.action[0] !== "/") {
 const honeypotName = `hp-${Date.now()}`;
 ---
 
-<form data-netlify="true" name={name} netlify-honeypot={honeypotName} {...rest}>
+<form data-source="astro-netlify-components" data-netlify="true" name={name} netlify-honeypot={honeypotName} {...rest}>
   <label>
     Don't fill this out if you're human:
     <input tabindex="-1" name={honeypotName} />

--- a/Identity.astro
+++ b/Identity.astro
@@ -1,0 +1,6 @@
+<script
+    data-source="astro-netlify-components"
+    is:inline
+    src="https://identity.netlify.com/v1/netlify-identity-widget.js"
+>
+</script>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Then import the components into your Astro project:
 ---
 import CMS from "astro-netlify-components/CMS.astro";
 import Form from "astro-netlify-components/Form.astro";
+import Identity from "astro-netlify-components/Identity.astro";
 ---
 ```
 
@@ -107,6 +108,27 @@ export interface Props extends HTMLAttributes<"form"> {
 `name` is the only required prop, and is used by Netlify to identify the form.
 
 If you pass an `action` prop that does not start with a `/`, then the component will throw an error. [Read Netlify's docs about success redirects](https://docs.netlify.com/forms/setup/#success-messages).
+
+### `Identity`
+
+A script tag to add to your `document.head` to enable [Netlify Identity](https://docs.netlify.com/visitor-access/identity/). This is used internally by `CMS` ([read more](https://www.netlifycms.org/docs/add-to-your-site/#add-the-netlify-identity-widget)).
+
+```astro
+---
+import Identity from "astro-netlify-components/Identity.astro";
+---
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <Identity />
+  </head>
+  <body>
+    <!-- ... -->
+  </body>
+</html>
+
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Astro components for Netlify",
   "files": [
     "CMS.astro",
-    "Form.astro"
+    "Form.astro",
+    "Identity.astro"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
This PR adds the `Identity` component for linking to the Netlify Identity script, and a `data-source=astro-netlify-components` attribute to the top-level element in every component.