### PR TITLE
Release/0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2023-02-06
+
 - Fix "Slots" heading level in README
 - Remove `astro` from `peerDependencies` (#8)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "astro-netlify-components",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "astro-netlify-components",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-netlify-components",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Astro components for Netlify",
   "files": [
     "CMS.astro",


### PR DESCRIPTION
- Fix "Slots" heading level in README
- Remove `astro` from `peerDependencies` (#8)